### PR TITLE
add --spidermonkey-obj-dir config var

### DIFF
--- a/configure
+++ b/configure
@@ -434,6 +434,11 @@ parser.add_option('--enable-gczeal',
     dest='enable_gczeal',
     help='enable SpiderMonkey gczeal')
 
+parser.add_option('--spidermonkey-obj-dir',
+    action='store',
+    dest='spidermonkey_obj_dir',
+    help='absolute path to SpiderMonkey obj dir')
+
 parser.add_option('--engine',
     action='store',
     dest='engine',
@@ -912,6 +917,7 @@ def configure_v8(o):
 
 def configure_spidermonkey(o):
   o['variables']['spidermonkey_gczeal'] = 1 if options.enable_gczeal else 0
+  o['variables']['spidermonkey_obj_dir'] = options.spidermonkey_obj_dir if options.spidermonkey_obj_dir else './'
 
 
 def configure_openssl(o):

--- a/deps/spidershim/spidershim.gyp
+++ b/deps/spidershim/spidershim.gyp
@@ -16,7 +16,7 @@
       'include_dirs': [
         'include',
         '<(SHARED_INTERMEDIATE_DIR)',
-        '/Users/bdahl/projects/positron/obj.debug.noindex/dist/include',
+        '<(spidermonkey_obj_dir)/dist/include',
       ],
       'conditions': [
         [ 'target_arch=="ia32"', { 'defines': [ '__i386__=1' ] } ],
@@ -44,9 +44,9 @@
         'libraries': [
           '-lspidershim',
           '-lz',
-          '/Users/bdahl/projects/positron/obj.debug.noindex/js/src/libjs_static.a',
-          '/Users/bdahl/projects/positron/obj.debug.noindex/mozglue/build/libmozglue.dylib',
-          '/Users/bdahl/projects/positron/obj.debug.noindex/dist/PositronDebug.app/Contents/MacOS/libnss3.dylib',
+          '<(spidermonkey_obj_dir)/js/src/libjs_static.a',
+          '<(spidermonkey_obj_dir)/mozglue/build/libmozglue.dylib',
+          '<(spidermonkey_obj_dir)/dist/PositronDebug.app/Contents/MacOS/libnss3.dylib',
         ],
         'conditions': [
           [ 'target_arch=="arm"', {


### PR DESCRIPTION
@brendandahl This adds a configuration variable to specify the SpiderMonkey obj dir, so you don't have to set paths manually.
