### PR TITLE
build static lib with -fPIC on Linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -286,6 +286,14 @@
           'BUILDING_UV_SHARED=1',
         ],
       }],
+      [ 'OS=="linux"', {
+        'target_conditions': [
+          ['_type=="static_library"', {
+            'cflags': [ '-fPIC', ],
+            'ldflags': [ '-fPIC' ],
+          }],
+        ],
+      }],
       [ 'OS in "linux freebsd openbsd solaris aix"', {
         'cflags': [ '-pthread', ],
         'ldflags': [ '-pthread' ],


### PR DESCRIPTION
@brendandahl This sets -fPIC when building SpiderNode as a static library on Linux.
